### PR TITLE
Fix/issue#13

### DIFF
--- a/src/Data/Array/Accelerate/Linear/Epsilon.hs
+++ b/src/Data/Array/Accelerate/Linear/Epsilon.hs
@@ -24,16 +24,16 @@ import Data.Array.Accelerate
 -- | Provides a fairly subjective test to see if a quantity is near zero.
 --
 -- >>> nearZero (1e-11 :: Exp Double)
--- False
+-- (0, ())
 --
 -- >>> nearZero (1e-17 :: Exp Double)
--- True
+-- (1, ())
 --
 -- >>> nearZero (1e-5 :: Exp Float)
--- False
+-- (0, ())
 --
 -- >>> nearZero (1e-7 :: Exp Float)
--- True
+-- (1, ())
 --
 class Num a => Epsilon a where
   -- | Determine if a quantity is near zero.

--- a/src/Data/Array/Accelerate/Linear/Plucker.hs
+++ b/src/Data/Array/Accelerate/Linear/Plucker.hs
@@ -56,7 +56,7 @@ module Data.Array.Accelerate.Linear.Plucker (
 import Data.Array.Accelerate                    hiding ( fromInteger, pattern V2, pattern V3, pattern V4 )
 import Data.Array.Accelerate.Data.Functor
 import Data.Array.Accelerate.Smart
-import Data.Array.Accelerate.Array.Sugar
+import Data.Array.Accelerate.Sugar.Elt
 
 import Data.Array.Accelerate.Linear.Epsilon
 import Data.Array.Accelerate.Linear.Lift
@@ -294,8 +294,11 @@ instance Functor Plucker where
   x <$ _                        = Plucker_ x x x x x x
 
 instance Elt LinePass where
-  type EltRepr LinePass = Int8
-  eltType = eltType @Int8
+  type EltR LinePass = Int8
+
+  eltR = eltR @Int8
+
+  tagsR = tagsR @Int8
 
   toElt x = let (==) = (P.==)   -- -XRebindableSyntax hax
             in  case x of


### PR DESCRIPTION
Fixes issue #13 .

tl;dr:

- I managed to keep most of `instance Elt LinePass`, the API changes weren't as big as I thought.
- Keeping the encoding as an Int8 is necessary for the `Eq` instance anyway
- Had to update some doctests for Epsilon because of an unrelated breakage: the `Show` instance for `Exp Bool` is now different.